### PR TITLE
Support for escape sequences

### DIFF
--- a/BLEConsole/Helpers.cs
+++ b/BLEConsole/Helpers.cs
@@ -9,6 +9,7 @@ using Windows.Security.Cryptography;
 using Windows.Storage.Streams;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Text.RegularExpressions;
 
 namespace BLEConsole
 {
@@ -436,7 +437,7 @@ namespace BLEConsole
                 // For text formats, use CryptographicBuffer
                 if (format == DataFormat.ASCII || format == DataFormat.UTF8)
                 {
-                    return CryptographicBuffer.ConvertStringToBinary(data, BinaryStringEncoding.Utf8);
+                    return CryptographicBuffer.ConvertStringToBinary(Regex.Unescape(data), BinaryStringEncoding.Utf8);
                 }
                 else
                 {


### PR DESCRIPTION
Allows the user to write things like `w #02/#01 \r\rAT+GPS=1\r` with escape sequences supported by [this](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.unescape).