### PR TITLE
Show error code if read/write fails

### DIFF
--- a/BLEConsole/Program.cs
+++ b/BLEConsole/Program.cs
@@ -879,7 +879,7 @@ namespace BLEConsole
                                 Console.WriteLine(Utilities.FormatValue(result.Value, _dataFormat));
                             else
                             {
-                                Console.WriteLine($"Read failed: {result.Status}");
+                                Console.WriteLine($"Read failed: {result.Status} 0x{result.ProtocolError:X2}");
                                 retVal += 1;
                             }
                         }
@@ -1010,7 +1010,7 @@ namespace BLEConsole
                                 if (result.Status != GattCommunicationStatus.Success)
                                 {
                                     if (!Console.IsOutputRedirected)
-                                        Console.WriteLine($"Write failed: {result.Status}");
+                                        Console.WriteLine($"Write failed: {result.Status} 0x{result.ProtocolError:X2}");
                                     retVal += 1;
                                 }
                             }


### PR DESCRIPTION
The protocol error code is important if you want to understand what is going wrong so IMHO it should be displayed...