### PR TITLE
Fix SDK + Update .NET Framework

### DIFF
--- a/BLEConsole/App.config
+++ b/BLEConsole/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/BLEConsole/BLEConsole.csproj
+++ b/BLEConsole/BLEConsole.csproj
@@ -29,7 +29,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>BLEConsole</RootNamespace>
     <AssemblyName>BLEConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>

--- a/BLEConsole/BLEConsole.csproj
+++ b/BLEConsole/BLEConsole.csproj
@@ -89,12 +89,12 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Windows\Microsoft.NET\assembly\GAC_MSIL\System.Runtime.WindowsRuntime\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.WindowsRuntime.dll</HintPath>
+      <HintPath>C:\Windows\Microsoft.NET\assembly\GAC_MSIL\System.Runtime.WindowsRuntime\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.WindowsRuntime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0\Windows.winmd</HintPath>
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0\Windows.winmd</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/compile_hint.txt
+++ b/compile_hint.txt
@@ -1,8 +1,13 @@
-This project may not compile right out of the box. I got:
+This project may not compile right out of the box. 
+It depends on the Windows SDK, you can install this using "Visual Studio Installer" by clicking modify and selecting the "Windows SDK" component.
+
+The following error indicates the Windows SDK is missing:
 "Error	CS0234	The type or namespace name 'Devices' does not exist in the namespace 'Windows' (are you missing an assembly reference?)"
 
-Apparently the following line of BLEConsole.csproj needed an update:
+If you installed the Windows SDK you might need to correct the version in te path.
+
+The following line of BLEConsole.csproj needs an update:
   <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
 
 The path must be corrected for the development machine's Windows Kit install. In my case:
-  <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd</HintPath>
+  <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0\Windows.winmd</HintPath>


### PR DESCRIPTION
Hello,

I noticed that the reference to the Windows SDK was set by a relative path instead of the absolute C:\ etc.
It is not ideal, but I think it has more chance of working than a relative path. (As the project location varies from person to person/pc to pc)
I also elaborated the compile_hints text file a bit.

Meanwhile I updated the .NET Framework version to the latest/stable 4.8 series. (.NET Framework 4.6.1 [support ended in 2022](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework))

I've tested this version over the weekend and found no issues.